### PR TITLE
feat: add ASCII handheld client and server build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+
+package-lock.json

--- a/devvit.yaml
+++ b/devvit.yaml
@@ -1,0 +1,19 @@
+post:
+  client:
+    dir: dist/client
+    entry: dist/client/index.html
+server:
+  entry: dist/server/index.cjs
+settings:
+  global:
+    - key: TITLE
+      type: string
+      label: Game Title
+      defaultValue: Reddi Console
+  subreddit:
+    - key: RESET_HOUR_UTC
+      type: number
+      label: Daily Reset Hour (UTC)
+      defaultValue: 0
+permissions:
+  images: false

--- a/package.json
+++ b/package.json
@@ -6,14 +6,16 @@
     "build:client": "vite build -c vite.client.config.ts",
     "build:server": "vite build -c vite.server.config.ts",
     "build": "npm run build:client && npm run build:server",
-    "dev": "devvit dev",
-    "deploy": "npm run build && devvit deploy"
+    "dev": "devvit-cli playtest",
+    "deploy": "npm run build && devvit-cli deploy"
   },
   "dependencies": {
+    "express": "^5.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@devvit/cli": "^0.10.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.6.2",


### PR DESCRIPTION
## Summary
- build ASCII handheld client with local state
- add minimal express server and Vite configs
- configure Devvit settings and dev tooling
- remove package-lock.json from repository

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68bf80e4e4888329ac30a1823a809a09