### PR TITLE
Add terms and privacy docs for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ npm run build
 devvit deploy
 ```
 
+## Legal
+
+This project includes a [Terms of Service](docs/terms.md) and a [Privacy Policy](docs/privacy.md). When GitHub Pages is enabled, these documents will be hosted at:
+
+- `https://<username>.github.io/reddi/terms`
+- `https://<username>.github.io/reddi/privacy`
+
 ## Notes
 
 All sprites are ASCII (original). No third-party assets. Parody naming ("Reddi") avoids direct Tamagotchi IP usage (no logos/sprites).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# reddi-pet Documentation
+
+This site hosts additional documentation for the reddi-pet project.
+
+- [Terms of Service](terms.md)
+- [Privacy Policy](privacy.md)

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,9 @@
+# Privacy Policy
+
+The reddi-pet project does not collect, store, or process personal information.
+
+- The source code and any builds are provided for use without tracking.
+- If you choose to contribute, your GitHub username and commits will be publicly visible
+  as part of normal GitHub functionality.
+
+If you have questions about this policy, please open an issue on the repository.

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,0 +1,9 @@
+# Terms of Service
+
+Welcome to the reddi-pet project. By using this project, you agree to the following terms:
+
+1. **No Warranty** - The software is provided "as-is" without any warranties.
+2. **Personal Use** - You may use and modify the project for personal or educational purposes.
+3. **Limitation of Liability** - The maintainers are not liable for any damages resulting from use of the project.
+
+If you have questions about these terms, please open an issue on the repository.


### PR DESCRIPTION
## Summary
- add Terms of Service and Privacy Policy under `docs/`
- link new legal pages from README and provide GitHub Pages URLs
- include a simple documentation index for the pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:client`
- `npm run build` *(fails: Rollup failed to resolve import "express" from "src/server/index.ts")*


------
https://chatgpt.com/codex/tasks/task_e_68c01f154fd48329bdc5f5e3a35ec812