### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,30 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run build:client
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/client
+      - uses: actions/deploy-pages@v4

--- a/vite.client.config.ts
+++ b/vite.client.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   root: 'src/client',
+  base: '/reddi/',
   build: {
     outDir: '../../dist/client',
     emptyOutDir: true


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow to build and deploy the client
- set Vite base path for GitHub Pages subdirectory

## Testing
- `npm test` (fails: Missing script)
- `npm run build:client`


------
https://chatgpt.com/codex/tasks/task_e_68c020db07448329b53de55bdfafffdd