### PR TITLE
feat(docs): ship Reddit-y Tamagotchi landing + themed docs for Reddi-Pet (static, no build)

### DIFF
--- a/docs/assets/css/theme.css
+++ b/docs/assets/css/theme.css
@@ -1,0 +1,54 @@
+:root{
+  --reddit:#FF4500; --ink:#0f172a; --ink-2:#1e293b; --shell:#fef6e4;
+  --mint:#c7f9cc; --sky:#e0f2fe;
+}
+*{box-sizing:border-box}
+body{font-family:Inter,system-ui,Segoe UI,Roboto,Apple Color Emoji,Noto Color Emoji,sans-serif}
+.font-display{font-family:"Press Start 2P", monospace}
+.bg-ink{background:linear-gradient(180deg,var(--ink),var(--ink-2))}
+.skip-link{position:absolute;left:-999px;top:auto}
+.skip-link:focus{left:1rem;top:1rem;background:#fff;color:#000;padding:.5rem 1rem;border-radius:.5rem}
+.h2{font-family:"Press Start 2P";letter-spacing:.5px;font-size:1.25rem;margin-bottom:1rem}
+.nav{color:rgb(203,213,225)}
+.nav:hover{color:#fff}
+.btn{display:inline-flex align-items:center gap:.5rem border:1px solid #334155 padding:.6rem 1rem border-radius:.8rem}
+.btn--primary{background:var(--reddit); border-color:transparent; color:white}
+.btn--ghost:hover{border-color:#64748b}
+
+.shell{
+  width:min(360px,92vw); margin-inline:auto; position:relative; 
+  background:radial-gradient(120% 100% at 50% 0%, var(--shell), #fff0);
+  border:6px solid #fee4c8; border-radius:28px; padding:18px; box-shadow:0 20px 60px #0006;
+}
+.shell__img{position:absolute; inset:0; opacity:.08; pointer-events:none}
+.lcd{
+  background:linear-gradient(#cbd5e1,#e2e8f0); border:4px solid #64748b; border-radius:12px;
+  aspect-ratio: 5/3; display:grid; place-items:center; position:relative; overflow:hidden;
+}
+.lcd::after{ /* scanlines */
+  content:""; position:absolute; inset:0; background:
+  repeating-linear-gradient(to bottom, #0001 0 2px, transparent 2px 4px);
+  pointer-events:none; mix-blend-mode:multiply;
+}
+.pixel-img{image-rendering: pixelated; width:140px; height:140px}
+.lcd__hud{position:absolute; inset:auto 8px 8px 8px; display:flex; gap:6px; justify-content:center}
+.hud-pill{font-family:"Press Start 2P"; font-size:.6rem; color:#0b1320; background:#94a3b8; padding:.25rem .5rem; border-radius:.5rem}
+.controls{display:flex; gap:10px; justify-content:center; margin-top:12px}
+.c-btn{font-size:1.1rem; background:#0b1320; color:#e2e8f0; border:1px solid #334155; border-radius:.7rem; padding:.45rem .8rem}
+.c-btn:active{transform:translateY(1px)}
+.feature-grid{display:grid; gap:14px; grid-template-columns: repeat(auto-fit,minmax(240px,1fr))}
+.card{background:linear-gradient(180deg,#0b1320,#0d1625); border:1px solid #223047; border-radius:14px; padding:16px}
+.card__title{font-weight:700; margin-bottom:.3rem}
+.card__body{color:#cbd5e1}
+.list{list-style:inside square; color:#cbd5e1}
+.doc-link{display:block; padding:14px 16px; border:1px dashed #334155; border-radius:12px}
+.doc-link:hover{border-style:solid; border-color:var(--reddit)}
+@media (prefers-reduced-motion:no-preference){
+  #pet.blink{animation:blink .8s steps(1) 1}
+  .shell{animation:float 6s ease-in-out infinite}
+}
+@keyframes blink{
+  0%,49%,100%{filter:none}
+  50%{filter:brightness(.6)}
+}
+@keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-6px)}}

--- a/docs/assets/js/app.js
+++ b/docs/assets/js/app.js
@@ -1,0 +1,46 @@
+/* tiny pet logic */
+const pet = document.getElementById('pet');
+const mood = document.getElementById('mood');
+const xp = document.getElementById('xp');
+const year = document.getElementById('year');
+if (year) year.textContent = new Date().getFullYear();
+
+let score = 1;
+let happy = 50;
+
+const sfx = (tone=880, ms=70) => {
+  try{
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    const ac = new (window.AudioContext||window.webkitAudioContext)();
+    const osc = ac.createOscillator();
+    const gain = ac.createGain();
+    osc.type = 'square'; osc.frequency.value = tone;
+    gain.gain.value = 0.02; osc.connect(gain); gain.connect(ac.destination);
+    osc.start(); setTimeout(()=>{osc.stop(); ac.close();}, ms);
+  }catch{}
+};
+
+const setMood = () => {
+  const label = happy>70?'Vibing': happy>45?'Chill': happy>20?'Meh':'Grumpy';
+  mood.textContent = `Mood: ${label}`;
+  xp.textContent = `XP: ${String(score).padStart(4,'0')}`;
+};
+
+document.querySelectorAll('.c-btn').forEach(btn=>{
+  btn.addEventListener('click', () => {
+    const act = btn.dataset.action;
+    if (act==='feed'){ happy=Math.min(100,happy+8); score+=2; sfx(660); }
+    if (act==='play'){ happy=Math.min(100,happy+6); score+=3; sfx(990); }
+    if (act==='clean'){ happy=Math.min(100,happy+4); score+=1; sfx(770); }
+    pet.classList.remove('blink'); void pet.offsetWidth; pet.classList.add('blink');
+    setMood();
+  });
+});
+
+/* idle blink every ~6–10s */
+setInterval(()=>{
+  if (document.hidden) return;
+  pet.classList.remove('blink'); void pet.offsetWidth; pet.classList.add('blink');
+}, 6000 + Math.random()*4000);
+
+setMood();

--- a/docs/assets/svg/egg-shell.svg
+++ b/docs/assets/svg/egg-shell.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 160">
+  <defs>
+    <linearGradient id="g" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#fff5e9"/>
+      <stop offset="1" stop-color="#fbe0bf"/>
+    </linearGradient>
+  </defs>
+  <rect width="240" height="160" rx="18" fill="url(#g)"/>
+  <circle cx="120" cy="140" r="100" fill="none" stroke="#ffd7a1" stroke-width="8"/>
+</svg>

--- a/docs/assets/svg/pet-blink.svg
+++ b/docs/assets/svg/pet-blink.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" shape-rendering="crispEdges">
+  <rect width="64" height="64" fill="#a7c7e7"/>
+  <rect x="20" y="20" width="24" height="24" fill="#0b1320"/>
+  <rect x="24" y="26" width="4" height="4" fill="#fff"/>
+  <rect x="36" y="26" width="4" height="4" fill="#fff"/>
+  <rect x="28" y="36" width="8" height="2" fill="#fff"/>
+</svg>

--- a/docs/assets/svg/pet-idle.svg
+++ b/docs/assets/svg/pet-idle.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" shape-rendering="crispEdges">
+  <rect width="64" height="64" fill="#a7c7e7"/>
+  <rect x="20" y="20" width="24" height="24" fill="#0b1320"/>
+  <rect x="24" y="26" width="4" height="4" fill="#fff"/>
+  <rect x="36" y="26" width="4" height="4" fill="#fff"/>
+  <rect x="28" y="36" width="8" height="2" fill="#fff"/>
+</svg>

--- a/docs/assets/svg/reddi-logo.svg
+++ b/docs/assets/svg/reddi-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none">
+  <circle cx="12" cy="12" r="10" stroke="#FF4500" stroke-width="2"/>
+  <circle cx="9" cy="11" r="1.5" fill="#FF4500"/>
+  <circle cx="15" cy="11" r="1.5" fill="#FF4500"/>
+  <path d="M7 15c1.2 1.2 3 2 5 2s3.8-.8 5-2" stroke="#FF4500" stroke-width="2" stroke-linecap="round"/>
+  <path d="M14 5l3 1" stroke="#FF4500" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Reddi-Pet — Reddit x Tamagotchi</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Press+Start+2P&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="./assets/css/theme.css" />
+  <meta name="description" content="Reddi-Pet: a Reddit-native virtual pet for interactive posts. Feed it with upvotes, comments, and daily prompts."/>
+</head>
+<body class="bg-ink text-slate-100 selection:bg-[var(--reddit)] selection:text-white">
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <!-- Nav -->
+  <header class="border-b border-slate-800/80 backdrop-blur supports-[backdrop-filter]:bg-ink/70 sticky top-0 z-40">
+    <div class="container mx-auto flex items-center justify-between px-4 py-3">
+      <div class="flex items-center gap-3">
+        <img src="./assets/svg/reddi-logo.svg" alt="" class="h-8 w-8">
+        <span class="font-extrabold tracking-tight">Reddi-Pet</span>
+      </div>
+      <nav class="flex items-center gap-4 text-sm">
+        <a class="nav" href="#how">How it works</a>
+        <a class="nav" href="#features">Features</a>
+        <a class="nav" href="#docs">Docs</a>
+        <a class="btn btn--primary" href="https://devpost.com/software/reddi-pet" target="_blank" rel="noreferrer">Demo</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Hero -->
+  <main id="main">
+    <section class="container mx-auto px-4 py-14 grid lg:grid-cols-2 gap-10 items-center">
+      <div>
+        <h1 class="font-display text-4xl md:text-5xl leading-tight">
+          A <span class="text-[var(--reddit)]">Reddit-native</span> virtual pet
+          that thrives on <span class="underline decoration-[var(--reddit)]">upvotes</span>.
+        </h1>
+        <p class="mt-5 text-slate-300 max-w-prose">
+          Meet <strong>Reddi-Pet</strong> — a Tamagotchi-style companion for
+          Reddit Interactive Posts. Feed it with <em>comments</em>, keep it happy with
+          <em>daily prompts</em>, and evolve it through <em>UGC mini-games</em>.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <a class="btn btn--primary" href="#docs">Get Started</a>
+          <a class="btn btn--ghost" href="#features">See Features</a>
+        </div>
+        <p class="mt-3 text-xs text-slate-400">Built for the Reddit Fun & Games Hackathon.</p>
+      </div>
+
+      <!-- Tamagotchi Shell -->
+      <div class="justify-self-center">
+        <div class="shell" aria-label="virtual pet shell">
+          <img class="shell__img" src="./assets/svg/egg-shell.svg" alt="">
+          <div class="lcd" role="img" aria-label="pet display">
+            <img id="pet" src="./assets/svg/pet-idle.svg" alt="pet idle" class="pixel-img" />
+            <div class="lcd__hud">
+              <span id="mood" class="hud-pill">Mood: Chill</span>
+              <span id="xp" class="hud-pill">XP: 0001</span>
+            </div>
+          </div>
+          <div class="controls">
+            <button class="c-btn" data-action="feed" aria-label="Feed">🍪</button>
+            <button class="c-btn" data-action="play" aria-label="Play">🕹️</button>
+            <button class="c-btn" data-action="clean" aria-label="Clean">🧼</button>
+          </div>
+        </div>
+        <p class="mt-3 text-center text-xs text-slate-400">Tip: Upvotes & comments in your post act like snacks & playtime.</p>
+      </div>
+    </section>
+
+    <!-- How it works -->
+    <section id="how" class="container mx-auto px-4 py-12">
+      <h2 class="h2">How it works</h2>
+      <div class="feature-grid">
+        <div class="card">
+          <h3 class="card__title">Attach to an Interactive Post</h3>
+          <p class="card__body">Embed Reddi-Pet in a Devvit Web interactive post. Readers can tap, react, and contribute UGC that affects the pet.</p>
+        </div>
+        <div class="card">
+          <h3 class="card__title">Community-fed</h3>
+          <p class="card__body">Upvotes, comments, and daily check-ins translate into hunger, happiness, and XP.</p>
+        </div>
+        <div class="card">
+          <h3 class="card__title">Evolutions</h3>
+          <p class="card__body">Hit milestones together to unlock pixel evolutions, badges, and flair-ready stickers.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Features -->
+    <section id="features" class="container mx-auto px-4 py-12">
+      <h2 class="h2">Features</h2>
+      <ul class="list">
+        <li>Pixel-perfect shell with LCD screen and subtle scanlines</li>
+        <li>Idle + blink animation, button SFX (respecting reduced-motion)</li>
+        <li>Themeable via CSS variables; light/dark auto</li>
+        <li>Docs anchors: API, embed guide, content policy, FAQ</li>
+      </ul>
+    </section>
+
+    <!-- Docs quick links -->
+    <section id="docs" class="container mx-auto px-4 py-12">
+      <h2 class="h2">Docs</h2>
+      <div class="grid sm:grid-cols-2 gap-4">
+        <a class="doc-link" href="./terms.html">Terms of Service</a>
+        <a class="doc-link" href="./privacy.html">Privacy Policy</a>
+      </div>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer class="border-t border-slate-800/60 mt-10">
+    <div class="container mx-auto px-4 py-8 text-sm flex flex-wrap items-center justify-between gap-3">
+      <span class="text-slate-400">© <span id="year"></span> Reddi-Pet</span>
+      <div class="flex items-center gap-4">
+        <a href="https://github.com/uxillary/reddi" class="nav">GitHub</a>
+        <a href="https://redditfunandgames.devpost.com/" class="nav">Hackathon</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="./assets/js/app.js"></script>
+</body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,0 @@
-# reddi-pet Documentation
-
-This site hosts additional documentation for the reddi-pet project.
-
-- [Terms of Service](terms.md)
-- [Privacy Policy](privacy.md)

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,14 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Privacy — Reddi-Pet</title>
+<link rel="stylesheet" href="./assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com"></script>
+</head><body class="bg-ink text-slate-100">
+  <header class="container mx-auto px-4 py-8">
+    <a href="./" class="nav">← Back to home</a>
+    <h1 class="h2 mt-4">Privacy Policy</h1>
+  </header>
+  <main class="container mx-auto px-4 prose prose-invert">
+    <p>Placeholder privacy policy. Add final legal text before release.</p>
+  </main>
+</body></html>

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,9 +1,0 @@
-# Privacy Policy
-
-The reddi-pet project does not collect, store, or process personal information.
-
-- The source code and any builds are provided for use without tracking.
-- If you choose to contribute, your GitHub username and commits will be publicly visible
-  as part of normal GitHub functionality.
-
-If you have questions about this policy, please open an issue on the repository.

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -1,0 +1,14 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Terms — Reddi-Pet</title>
+<link rel="stylesheet" href="./assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com"></script>
+</head><body class="bg-ink text-slate-100">
+  <header class="container mx-auto px-4 py-8">
+    <a href="./" class="nav">← Back to home</a>
+    <h1 class="h2 mt-4">Terms of Service</h1>
+  </header>
+  <main class="container mx-auto px-4 prose prose-invert">
+    <p>Placeholder terms. Add final legal text before release.</p>
+  </main>
+</body></html>

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,9 +1,0 @@
-# Terms of Service
-
-Welcome to the reddi-pet project. By using this project, you agree to the following terms:
-
-1. **No Warranty** - The software is provided "as-is" without any warranties.
-2. **Personal Use** - You may use and modify the project for personal or educational purposes.
-3. **Limitation of Liability** - The maintainers are not liable for any damages resulting from use of the project.
-
-If you have questions about these terms, please open an issue on the repository.


### PR DESCRIPTION
## Summary
- replace minimal markdown docs with Reddit-inspired Tamagotchi landing page
- add themed Terms and Privacy pages with shared styling and assets
- include interactive pet shell, blink animation, and tiny SFX using pure static assets

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1fb1a0aac8329bc9327036e564289