### PR TITLE
Add bored mood with yawning sprite

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -72,6 +72,7 @@ export default function App() {
     if (pet.hunger > 70) return 'hungry';
     if (pet.clean < 30) return 'dirty';
     if (pet.fun > 80) return 'happy';
+    if (pet.fun < 30) return 'bored';
     return 'idle';
   }, [pet]);
 

--- a/src/client/ascii.ts
+++ b/src/client/ascii.ts
@@ -1,4 +1,4 @@
-export type Mood = 'idle' | 'happy' | 'hungry' | 'dirty' | 'sleep';
+export type Mood = 'idle' | 'happy' | 'hungry' | 'dirty' | 'sleep' | 'bored';
 
 export function petSprite(mood: Mood, frame = 0): string {
   // Two simple frames for a subtle “blink/wiggle”
@@ -41,6 +41,16 @@ export function petSprite(mood: Mood, frame = 0): string {
 | |  - - | | z
 |  \ __/  |  z
  \  '--'  /   z
+  '-.__.-'`;
+  }
+  if (mood === 'bored') {
+    return String.raw`
+  .-""""-.
+ /  .--.  \
+|  /    \  |
+| |  - - | |
+|  \ ___/  |
+ \  '--'  /
   '-.__.-'`;
   }
   // idle


### PR DESCRIPTION
## Summary
- add bored mood type and ASCII sprite
- display bored mood when pet's fun is low

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc --noEmit` (shows TypeScript options, no config)


------
https://chatgpt.com/codex/tasks/task_e_68c724982d3c8329a8117ee85adb80b0