### PR TITLE
Fix client entry path for interactive posts

### DIFF
--- a/devvit.json
+++ b/devvit.json
@@ -1,6 +1,6 @@
 {
   "post": {
-    "client": { "dir": "dist/client", "entry": "dist/client/index.html" }
+    "client": { "dir": "dist/client", "entry": "index.html" }
   },
   "server": { "entry": "dist/server/index.cjs" },
   "settings": {

--- a/devvit.yaml
+++ b/devvit.yaml
@@ -1,7 +1,7 @@
 post:
   client:
     dir: dist/client
-    entry: dist/client/index.html
+    entry: index.html
 server:
   entry: dist/server/index.cjs
 settings:


### PR DESCRIPTION
## Summary
- correct Devvit manifest entry for client build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c75eaf8e588329b3d97f00c15974df