### PR TITLE
Ensure menu endpoint is available during playtest

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,8 +1,27 @@
 import express from 'express';
+import type { Request, Response } from 'express';
+import { createPost } from './core/post.js';
+
 const app = express();
 app.use(express.json());
 
 // Health probe (Devvit Web hits your bundled server code)
 app.get('/api/health', (_req, res) => res.json({ ok: true }));
+
+app.post('/internal/menu/post-create', async (_req: Request, res: Response) => {
+  try {
+    const post = await createPost();
+    res.json(post);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Failed to create interactive post', error);
+    res.status(500).json({ error: message });
+  }
+});
+
+const port = Number(process.env.PORT ?? 3000);
+app.listen(port, '0.0.0.0', () => {
+  console.log(`[server] listening on port ${port}`);
+});
 
 export default app;


### PR DESCRIPTION
## Summary
- start the Express server on the provided port so the Devvit CLI can reach it
- add a `/internal/menu/post-create` route that invokes the existing `createPost` helper and returns the API response
- log and surface failures when the post creation endpoint encounters an error

## Testing
- `npm run build` *(fails: missing dependency `@tailwindcss/vite` in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cab49aaf9883299e26a57f245f5596