### PR TITLE
Wrap Express server with Devvit context

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import type { Request, Response } from 'express';
+import { createServer } from '@devvit/web/server';
 import { createPost } from './core/post.js';
 
 const app = express();
@@ -19,9 +20,11 @@ app.post('/internal/menu/post-create', async (_req: Request, res: Response) => {
   }
 });
 
+const server = createServer((req, res) => app(req, res));
+
 const port = Number(process.env.PORT ?? 3000);
-app.listen(port, '0.0.0.0', () => {
+server.listen(port, '0.0.0.0', () => {
   console.log(`[server] listening on port ${port}`);
 });
 
-export default app;
+export default server;


### PR DESCRIPTION
## Summary
- wrap the express app with Devvit's createServer to ensure request context is available
- start listening on the Devvit server instead of the express app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cab74bf7048329921c7b89c33fa83d