### PR TITLE
Fix interactive post creation response

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -33,7 +33,9 @@ function load(): Pet {
       const data = JSON.parse(raw) as Partial<Pet>;
       if (!data.born) data.born = data.dayId ?? todayId();
       return data as Pet;
-    } catch {}
+    } catch (error) {
+      console.warn('Failed to parse saved pet data', error);
+    }
   }
   return defaultPet();
 }

--- a/src/server/core/post.ts
+++ b/src/server/core/post.ts
@@ -1,16 +1,32 @@
 import { context, reddit } from '@devvit/web/server';
 
-export const createPost = async () => {
+export type MenuResponse = {
+  showToast?: {
+    message: string;
+    type?: 'success' | 'error';
+  };
+  navigateTo?: string;
+};
+
+export const createPost = async (): Promise<MenuResponse> => {
   const { subredditName } = context;
   if (!subredditName) {
     throw new Error('subredditName is required');
   }
 
-  return await reddit.submitCustomPost({
+  const post = await reddit.submitCustomPost({
     splash: {
       appDisplayName: 'reddy-pet',
     },
-    subredditName: subredditName,
+    subredditName,
     title: 'reddy-pet',
   });
+
+  return {
+    showToast: {
+      message: 'Interactive post created!',
+      type: 'success',
+    },
+    navigateTo: post.permalink ?? `/r/${subredditName}`,
+  };
 };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,12 +11,17 @@ app.get('/api/health', (_req, res) => res.json({ ok: true }));
 
 app.post('/internal/menu/post-create', async (_req: Request, res: Response) => {
   try {
-    const post = await createPost();
-    res.json(post);
+    const response = await createPost();
+    res.json(response);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     console.error('Failed to create interactive post', error);
-    res.status(500).json({ error: message });
+    res.json({
+      showToast: {
+        message: `Failed to create interactive post: ${message}`,
+        type: 'error',
+      },
+    });
   }
 });
 


### PR DESCRIPTION
## Summary
- return a valid UI response from the interactive post creation endpoint so the playtest menu succeeds
- surface success feedback and navigate to the new post while gracefully handling failures with an error toast
- log when saved pet data cannot be parsed to satisfy lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cabcfecb3c83298d419192d524b8c1