### PR TITLE
Add retro-themed blog hub to docs

### DIFF
--- a/docs/assets/css/theme.css
+++ b/docs/assets/css/theme.css
@@ -43,6 +43,31 @@ body{font-family:Inter,system-ui,Segoe UI,Roboto,Apple Color Emoji,Noto Color Em
 .list{list-style:inside square; color:#cbd5e1}
 .doc-link{display:block; padding:14px 16px; border:1px dashed #334155; border-radius:12px}
 .doc-link:hover{border-style:solid; border-color:var(--reddit)}
+.blog-header{display:flex; align-items:center; justify-content:space-between; gap:1.5rem; flex-wrap:wrap}
+.blog-subtitle{color:#cbd5e1; max-width:32rem}
+.blog-grid{display:grid; margin-top:1.5rem; gap:16px; grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
+.blog-card{position:relative; border:1px solid #223047; border-radius:16px; padding:20px; background:linear-gradient(135deg,#0c1322,#131f33)}
+.blog-card::before{content:""; position:absolute; inset:12px; border-radius:14px; border:1px dashed #334155; opacity:.7; pointer-events:none}
+.blog-card:hover{border-color:var(--reddit); box-shadow:0 0 0 2px #ff450022}
+.blog-card__meta{font-size:.75rem; font-family:"Press Start 2P"; letter-spacing:.5px; text-transform:uppercase; color:#f97316}
+.blog-card__title{margin-top:.8rem; font-size:1.1rem; font-weight:700}
+.blog-card__excerpt{margin-top:.5rem; color:#cbd5e1}
+.blog-card__cta{margin-top:1.1rem; display:inline-flex; align-items:center; gap:.4rem; color:var(--mint); font-weight:600}
+.blog-card__cta::after{content:"→"; font-family:"Press Start 2P"; font-size:.55rem}
+.blog-card--loading{background:repeating-linear-gradient(135deg,#0c1322 0 20px,#111b2c 20px 40px)}
+.blog-empty{margin-top:1.5rem; color:#94a3b8; font-size:.9rem}
+.blog-empty code{font-family:"Press Start 2P",monospace; font-size:.7rem; color:#f97316}
+.blog-article{margin-top:2.5rem; max-width:65ch; font-size:1.05rem; line-height:1.75}
+.blog-article h2{font-size:1.65rem; margin-top:2.4rem; margin-bottom:1rem; font-weight:700}
+.blog-article h3{font-size:1.3rem; margin-top:1.8rem; margin-bottom:.7rem; font-weight:700}
+.blog-article p{margin-top:1rem; color:#e2e8f0}
+.blog-article a{color:var(--mint); text-decoration:underline dotted}
+.blog-article ul,.blog-article ol{margin:1.2rem 0 1.2rem 1.2rem; padding:0; color:#e2e8f0}
+.blog-article li{margin-bottom:.6rem}
+.blog-article blockquote{margin:1.4rem 0; padding:1rem 1.2rem; border-left:4px solid var(--reddit); background:#1b293f; color:#f8fafc; border-radius:12px}
+.blog-article code{font-family:"Press Start 2P",monospace; font-size:.7rem; background:#0b1320; padding:.2rem .35rem; border-radius:.4rem}
+.blog-article pre{background:#0b1320; color:#f1f5f9; padding:1rem 1.2rem; border-radius:14px; overflow:auto; font-size:.85rem; line-height:1.6}
+.blog-error{margin-top:2rem; padding:1.5rem; border:1px dashed #334155; border-radius:14px; background:#0b1320; color:#f8fafc; max-width:42ch}
 @media (prefers-reduced-motion:no-preference){
   #pet.blink{animation:blink .8s steps(1) 1}
   .shell{animation:float 6s ease-in-out infinite}

--- a/docs/assets/js/blog.js
+++ b/docs/assets/js/blog.js
@@ -1,0 +1,94 @@
+(function () {
+  const listEl = document.querySelector('[data-blog-list]');
+  if (!listEl) return;
+
+  const loadingEl = listEl.querySelector('[data-blog-loading]');
+  const emptyEl = document.querySelector('[data-blog-empty]');
+  const limitAttr = listEl.getAttribute('data-blog-limit');
+  const limit = limitAttr ? parseInt(limitAttr, 10) : 3;
+  const manifestPath = listEl.getAttribute('data-blog-manifest') || './blog/posts.json';
+  const basePath = listEl.getAttribute('data-blog-base') || './blog';
+  const viewerBase = basePath.replace(/\/$/, '');
+
+  const clearLoading = () => {
+    if (loadingEl && loadingEl.parentElement) {
+      loadingEl.parentElement.removeChild(loadingEl);
+    }
+  };
+
+  const showEmpty = () => {
+    clearLoading();
+    if (emptyEl) {
+      emptyEl.hidden = false;
+    }
+  };
+
+  const formatDate = (value) => {
+    if (!value) return '';
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return value;
+    return parsed.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  const renderPost = (post) => {
+    const article = document.createElement('article');
+    article.className = 'blog-card';
+
+    const meta = document.createElement('div');
+    meta.className = 'blog-card__meta';
+    const bits = [];
+    if (post.date) bits.push(formatDate(post.date));
+    if (post.tagline) bits.push(post.tagline);
+    meta.textContent = bits.join(' • ') || 'Fresh drop';
+
+    const title = document.createElement('h3');
+    title.className = 'blog-card__title';
+    title.textContent = post.title || post.slug;
+
+    const excerpt = document.createElement('p');
+    excerpt.className = 'blog-card__excerpt';
+    excerpt.textContent = post.description || 'Crack open the shell to read more.';
+
+    const cta = document.createElement('a');
+    cta.className = 'blog-card__cta';
+    cta.href = `${viewerBase}/viewer.html?post=${encodeURIComponent(post.slug)}`;
+    cta.textContent = 'Read update';
+
+    article.append(meta, title, excerpt, cta);
+    listEl.appendChild(article);
+  };
+
+  const hydrate = (posts) => {
+    clearLoading();
+    if (!posts || posts.length === 0) {
+      showEmpty();
+      return;
+    }
+
+    const count = Number.isFinite(limit) && limit > 0 ? limit : posts.length;
+    posts.slice(0, count).forEach(renderPost);
+  };
+
+  fetch(manifestPath, { cache: 'no-store' })
+    .then((res) => {
+      if (!res.ok) throw new Error('network');
+      return res.json();
+    })
+    .then((data) => {
+      if (Array.isArray(data)) {
+        hydrate(data);
+      } else if (Array.isArray(data.posts)) {
+        hydrate(data.posts);
+      } else {
+        throw new Error('bad manifest');
+      }
+    })
+    .catch((error) => {
+      console.warn('Unable to load blog posts', error);
+      showEmpty();
+    });
+})();

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Reddi-Pet Blog</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Press+Start+2P&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="../assets/css/theme.css" />
+  <meta name="description" content="Dev logs, changelogs, and tamagotchi telemetry straight from the Reddi-Pet team." />
+</head>
+<body class="bg-ink text-slate-100 selection:bg-[var(--reddit)] selection:text-white">
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="border-b border-slate-800/80 backdrop-blur supports-[backdrop-filter]:bg-ink/70 sticky top-0 z-40">
+    <div class="container mx-auto flex items-center justify-between px-4 py-3">
+      <div class="flex items-center gap-3">
+        <img src="../assets/svg/reddi-logo.svg" alt="" class="h-8 w-8">
+        <span class="font-extrabold tracking-tight">Reddi-Pet</span>
+      </div>
+      <nav class="flex items-center gap-4 text-sm">
+        <a class="nav" href="../index.html">Home</a>
+        <a class="nav" href="../index.html#how">How it works</a>
+        <a class="nav" href="../index.html#features">Features</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="container mx-auto px-4 py-14">
+      <div class="max-w-2xl">
+        <p class="blog-card__meta">Dev Log</p>
+        <h1 class="font-display text-3xl md:text-4xl leading-tight mt-3">Reddi-Pet Signal Boost</h1>
+        <p class="mt-4 text-slate-300">
+          Patch notes, experiments, and community spotlights. Every post hatches from a <code>.mdx</code> dropped in
+          <span class="font-semibold">/docs/blog</span>.
+        </p>
+      </div>
+
+      <div class="blog-grid" data-blog-list data-blog-limit="0" data-blog-manifest="./posts.json" data-blog-base=".">
+        <article class="blog-card blog-card--loading" data-blog-loading>
+          <div class="blog-card__meta">Spinning up modem…</div>
+          <h3 class="blog-card__title">Loading pixel updates</h3>
+          <p class="blog-card__excerpt">If this sticks around, double-check your manifest or file paths.</p>
+        </article>
+      </div>
+
+      <p class="blog-empty" data-blog-empty hidden>
+        Your pet is snoozing. Add a new <code>.mdx</code> file and list it in <code>posts.json</code> to publish an update.
+      </p>
+    </section>
+  </main>
+
+  <footer class="border-t border-slate-800/60 mt-10">
+    <div class="container mx-auto px-4 py-8 text-sm flex flex-wrap items-center justify-between gap-3">
+      <span class="text-slate-400">© <span id="year"></span> Reddi-Pet</span>
+      <div class="flex items-center gap-4">
+        <a href="https://github.com/uxillary/reddi" class="nav">GitHub</a>
+        <a href="https://redditfunandgames.devpost.com/" class="nav">Hackathon</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../assets/js/blog.js"></script>
+  <script>
+    const year = document.getElementById('year');
+    if (year) year.textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/docs/blog/posts.json
+++ b/docs/blog/posts.json
@@ -1,0 +1,18 @@
+{
+  "posts": [
+    {
+      "slug": "welcome-to-the-pixel-hatchery",
+      "title": "Welcome to the Pixel Hatchery",
+      "description": "How Reddi-Pet blends Tamagotchi nostalgia with Reddit's hive mind.",
+      "date": "2025-02-10",
+      "tagline": "Dev Log"
+    },
+    {
+      "slug": "tamagotchi-telemetry-001",
+      "title": "Telemetry 001: Feeding Frenzy",
+      "description": "Exploring how upvotes, comments, and check-ins keep your companion thriving.",
+      "date": "2025-02-03",
+      "tagline": "Changelog"
+    }
+  ]
+}

--- a/docs/blog/tamagotchi-telemetry-001.mdx
+++ b/docs/blog/tamagotchi-telemetry-001.mdx
@@ -1,0 +1,30 @@
+---
+title: Telemetry 001 — Feeding Frenzy
+date: 2025-02-03
+tagline: Changelog
+description: Exploring how upvotes, comments, and check-ins keep your companion thriving.
+---
+
+## Patch TL;DR
+
+- Tuned the hunger decay curve so late-night lurkers don't starve the pet.
+- Added a celebratory sparkle animation when the community smashes a milestone.
+- Surfaced a mini-dashboard so mods can peek at mood, hunger, and XP trends.
+
+## Stat Stream
+
+| Signal | Source | Effect |
+| ------ | ------ | ------ |
+| Hunger | Upvotes | +2 XP per 50 upvotes |
+| Happiness | Comments | +1 mood per 5 thoughtful replies |
+| Cleanliness | Daily prompts | +3 mood per completed ritual |
+
+We're logging each signal to generate heatmaps for the next patch. Expect a follow-up report with the spiciest subs keeping their pets happiest.
+
+## Caretaker Spotlight
+
+> "We stuck Reddi-Pet in our meme thread and suddenly the whole sub was role-playing as pixel vets." — u/CRTChampion
+
+If your community cracked a new care pattern, submit a `.mdx` breakdown and add it to `posts.json`. The homepage will highlight the freshest three entries automatically.
+
+Until the next check-in: keep the snacks stocked and the prompts playful.

--- a/docs/blog/viewer.html
+++ b/docs/blog/viewer.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Reddi-Pet Blog Post</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Press+Start+2P&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="../assets/css/theme.css" />
+  <meta name="description" content="Deep dives and patch notes from the Reddi-Pet tamagotchi." />
+</head>
+<body class="bg-ink text-slate-100 selection:bg-[var(--reddit)] selection:text-white">
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="border-b border-slate-800/80 backdrop-blur supports-[backdrop-filter]:bg-ink/70 sticky top-0 z-40">
+    <div class="container mx-auto flex items-center justify-between px-4 py-3">
+      <div class="flex items-center gap-3">
+        <img src="../assets/svg/reddi-logo.svg" alt="" class="h-8 w-8">
+        <span class="font-extrabold tracking-tight">Reddi-Pet</span>
+      </div>
+      <nav class="flex items-center gap-4 text-sm">
+        <a class="nav" href="../index.html">Home</a>
+        <a class="nav" href="./index.html">Blog</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" class="container mx-auto px-4 py-14">
+    <div class="max-w-3xl">
+      <p class="blog-card__meta js-post-meta">Loading…</p>
+      <h1 class="font-display text-3xl md:text-4xl leading-tight mt-3 js-post-title">Dialing into the feed…</h1>
+      <p class="mt-3 text-slate-300 js-post-description"></p>
+    </div>
+
+    <article class="blog-article js-post-body">
+      <p class="text-slate-400">Booting up your story.</p>
+    </article>
+
+    <div class="blog-error hidden js-post-error">
+      <p>We couldn't find that post. Double-check the <code>post</code> query param or make sure the file exists.</p>
+      <a class="btn btn--ghost mt-4 inline-flex" href="./index.html">← Back to blog index</a>
+    </div>
+  </main>
+
+  <footer class="border-t border-slate-800/60 mt-10">
+    <div class="container mx-auto px-4 py-8 text-sm flex flex-wrap items-center justify-between gap-3">
+      <span class="text-slate-400">© <span id="year"></span> Reddi-Pet</span>
+      <div class="flex items-center gap-4">
+        <a href="https://github.com/uxillary/reddi" class="nav">GitHub</a>
+        <a href="https://redditfunandgames.devpost.com/" class="nav">Hackathon</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script>
+    (function () {
+      const params = new URLSearchParams(window.location.search);
+      const slug = params.get('post');
+      const titleEl = document.querySelector('.js-post-title');
+      const metaEl = document.querySelector('.js-post-meta');
+      const descriptionEl = document.querySelector('.js-post-description');
+      const bodyEl = document.querySelector('.js-post-body');
+      const errorEl = document.querySelector('.js-post-error');
+      const year = document.getElementById('year');
+      if (year) year.textContent = new Date().getFullYear();
+
+      if (!slug) {
+        if (errorEl) errorEl.classList.remove('hidden');
+        if (bodyEl) bodyEl.innerHTML = '';
+        if (metaEl) metaEl.textContent = 'Missing slug';
+        if (titleEl) titleEl.textContent = 'No post selected';
+        return;
+      }
+
+      const manifestPath = './posts.json';
+
+      const applyMeta = (post) => {
+        if (!post) return;
+        if (titleEl) titleEl.textContent = post.title || slug;
+        if (descriptionEl) descriptionEl.textContent = post.description || '';
+        if (metaEl) {
+          const date = post.date ? new Date(post.date) : null;
+          const formatted = date && !Number.isNaN(date.getTime())
+            ? date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+            : null;
+          const bits = [];
+          if (post.tagline) bits.push(post.tagline);
+          if (formatted) bits.push(formatted);
+          metaEl.textContent = bits.join(' • ') || 'Reddi-Pet Broadcast';
+        }
+      };
+
+      const renderContent = (raw) => {
+        if (!bodyEl) return;
+        let content = raw.trim();
+        if (content.startsWith('---')) {
+          const fm = content.match(/^---[\s\S]*?---\s*/);
+          if (fm) {
+            content = content.slice(fm[0].length).trimStart();
+          }
+        }
+        bodyEl.innerHTML = marked.parse(content, { mangle: false, headerIds: false });
+      };
+
+      fetch(manifestPath, { cache: 'no-store' })
+        .then((res) => {
+          if (!res.ok) throw new Error('manifest');
+          return res.json();
+        })
+        .then((data) => {
+          const posts = Array.isArray(data) ? data : data.posts;
+          if (!Array.isArray(posts)) throw new Error('manifest');
+          const post = posts.find((item) => item.slug === slug);
+          if (!post) throw new Error('missing');
+          applyMeta(post);
+          return fetch(`./${slug}.mdx`, { cache: 'no-store' });
+        })
+        .then((res) => {
+          if (!res.ok) throw new Error('content');
+          return res.text();
+        })
+        .then((text) => {
+          renderContent(text);
+        })
+        .catch((error) => {
+          console.warn('Unable to render blog post', error);
+          if (errorEl) errorEl.classList.remove('hidden');
+          if (bodyEl) bodyEl.innerHTML = '';
+          if (metaEl) metaEl.textContent = '404';
+          if (titleEl) titleEl.textContent = 'Post offline';
+        });
+    })();
+  </script>
+</body>
+</html>

--- a/docs/blog/welcome-to-the-pixel-hatchery.mdx
+++ b/docs/blog/welcome-to-the-pixel-hatchery.mdx
@@ -1,0 +1,34 @@
+---
+title: Welcome to the Pixel Hatchery
+date: 2025-02-10
+tagline: Dev Log
+description: How Reddi-Pet blends Tamagotchi nostalgia with Reddit's hive mind.
+---
+
+## Hatching Day
+
+Our shell just cracked! Reddi-Pet is a Tamagotchi-inspired companion that plugs directly into Reddit Interactive Posts. Every tap, upvote, and comment becomes nutrition for the tiny creature living inside the LCD.
+
+Here is what we focused on for the initial release:
+
+- **Reddit-native gameplay.** We built the pet with Devvit so it can live right inside a post and soak up the community's energy.
+- **Authentic 90s texture.** Pixel art, scanlines, and crunchy button tones keep the nostalgia dial turned to max.
+- **Mod-friendly DNA.** The stat engine is open for creator tweaks—swap snacks, remix evolutions, or write new mini-games.
+
+## Feeding Rituals
+
+To keep the pet thriving, we mapped classic Tamagotchi needs to Reddit mechanics:
+
+1. **Hunger → Upvotes.** Every upvote dispenses a sprinkle of XP kibble.
+2. **Happiness → Comments.** Conversations act like mini-play sessions.
+3. **Cleanliness → Daily prompts.** Answer the prompt, wipe the screen, keep the mood high.
+
+If you're planning to mod Reddi-Pet, drop your own rituals into the scripts folder, update `posts.json`, and watch them auto-populate this blog.
+
+> Tip: ship an animated gif of your pet's latest evolution as the thumbnail inside your post. It converts scrollers into caretakers instantly.
+
+## What's Next
+
+We're already prototyping a **community boss fight** that lets multiple subs pool stats to hatch a legendary pet. Keep an eye on this feed for telemetry on that experiment!
+
+Stay crunchy, keep feeding your pet, and ping us on Reddit if you build something wild.

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,6 +23,7 @@
       <nav class="flex items-center gap-4 text-sm">
         <a class="nav" href="#how">How it works</a>
         <a class="nav" href="#features">Features</a>
+        <a class="nav" href="#blog">Blog</a>
         <a class="nav" href="#docs">Docs</a>
         <a class="btn btn--primary" href="https://devpost.com/software/reddi-pet" target="_blank" rel="noreferrer">Demo</a>
       </nav>
@@ -100,6 +101,29 @@
       </ul>
     </section>
 
+    <!-- Blog -->
+    <section id="blog" class="container mx-auto px-4 py-12">
+      <div class="blog-header">
+        <div>
+          <h2 class="h2">Pixel Patch Notes</h2>
+          <p class="blog-subtitle">Latest transmissions from the Reddi-Pet lab.</p>
+        </div>
+        <a class="btn btn--ghost" href="./blog/index.html">See all posts</a>
+      </div>
+
+      <div class="blog-grid" data-blog-list data-blog-manifest="./blog/posts.json" data-blog-base="./blog">
+        <article class="blog-card blog-card--loading" data-blog-loading>
+          <div class="blog-card__meta">Syncing blog feed…</div>
+          <h3 class="blog-card__title">Fetching tamagotchi gossip</h3>
+          <p class="blog-card__excerpt">Give us a sec while we dial up the modem.</p>
+        </article>
+      </div>
+
+      <p class="blog-empty" data-blog-empty hidden>
+        No posts yet! Feed your Reddi-Pet a fresh .mdx file in <code>/docs/blog</code> to wake this feed up.
+      </p>
+    </section>
+
     <!-- Docs quick links -->
     <section id="docs" class="container mx-auto px-4 py-12">
       <h2 class="h2">Docs</h2>
@@ -122,5 +146,6 @@
   </footer>
 
   <script src="./assets/js/app.js"></script>
+  <script src="./assets/js/blog.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a retro-styled blog feed to the docs homepage that hydrates from `/docs/blog`
- add shared blog loader script, index page, and viewer that render `.mdx` entries listed in `posts.json`
- extend docs styling and seed the blog directory with example manifest and posts

## Testing
- not run (static docs change)


------
https://chatgpt.com/codex/tasks/task_e_68cd4189036c83299758eef35c757ed5