### PR TITLE
Add resource links to pet console

### DIFF
--- a/docs/assets/css/theme.css
+++ b/docs/assets/css/theme.css
@@ -11,7 +11,7 @@ body{font-family:Inter,system-ui,Segoe UI,Roboto,Apple Color Emoji,Noto Color Em
 .h2{font-family:"Press Start 2P";letter-spacing:.5px;font-size:1.25rem;margin-bottom:1rem}
 .nav{color:rgb(203,213,225)}
 .nav:hover{color:#fff}
-.btn{display:inline-flex align-items:center gap:.5rem border:1px solid #334155 padding:.6rem 1rem border-radius:.8rem}
+.btn{display:inline-flex; align-items:center; gap:.5rem; border:1px solid #334155; padding:.6rem 1rem; border-radius:.8rem}
 .btn--primary{background:var(--reddit); border-color:transparent; color:white}
 .btn--ghost:hover{border-color:#64748b}
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -105,8 +105,16 @@ export default function App() {
 
   const ascii = petSprite(mood, frame.current);
   const asciiLines = ascii.split('\n');
-  while (asciiLines.length && asciiLines[0].trim() === '') asciiLines.shift();
-  while (asciiLines.length && asciiLines[asciiLines.length - 1].trim() === '') asciiLines.pop();
+  while (asciiLines.length) {
+    const first = asciiLines[0];
+    if (!first || first.trim() !== '') break;
+    asciiLines.shift();
+  }
+  while (asciiLines.length) {
+    const last = asciiLines[asciiLines.length - 1];
+    if (!last || last.trim() !== '') break;
+    asciiLines.pop();
+  }
   const asciiFace = asciiLines.map(line => line.replace(/\s+$/, '')).join('\n');
 
   // Simple “evolution” badge for later: show stage by aggregate health
@@ -157,6 +165,12 @@ export default function App() {
           </div>
 
           <div className="meta">★ EGG-{eggId} • Day {day}</div>
+          <nav className="links">
+            <a href="https://github.com/uxillary/reddi" target="_blank" rel="noreferrer">Reddi Repo</a>
+            <a href="https://github.com/uxillary" target="_blank" rel="noreferrer">GitHub</a>
+            <a href="https://adamj.link" target="_blank" rel="noreferrer">adamj.link</a>
+            <a href="https://devpost.com/software/reddi-pet" target="_blank" rel="noreferrer">Reddi App</a>
+          </nav>
         </div>
       </div>
     </div>

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -95,6 +95,9 @@ html,body,#root{ height:100%; margin:0; background: radial-gradient(1200px 800px
 .btn--primary{ background: linear-gradient(180deg, #1d7458, #125a45); }
 .btn--danger{ background: linear-gradient(180deg, #9a2e26, #7e211a); }
 .meta{ margin-top:10px; text-align:center; font-size:12px; color:var(--text-dim) }
+.links{ margin-top:12px; display:flex; flex-wrap:wrap; justify-content:center; gap:12px; font-size:12px; }
+.links a{ color:var(--accent-3); text-decoration:none; border-bottom:1px dashed transparent; transition: color .2s ease, border-color .2s ease; }
+.links a:hover{ color:var(--text); border-color:var(--accent-3); }
 
 .badge{ font-size:11px; padding:3px 8px; border-radius:999px; background:#122d25; color:var(--accent-3); border:1px solid rgba(127,255,212,.2); letter-spacing:.6px; text-transform:uppercase; }
 


### PR DESCRIPTION
## Summary
- add safety trimming helper for the ASCII art lines
- add a footer links section with references to the repo, GitHub profile, adamj.link, and the Reddi app
- style the new links navigation and fix the docs button CSS declaration

## Testing
- npm run type-check
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd4583342883299007fab9987df124