### PR TITLE
Add concept image to docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,3 +6,5 @@ Explore Reddi-Pet across the web:
 - [Adam Johnson on GitHub](https://github.com/uxillary)
 - [Adam Johnson's Hub](https://adamj.link)
 - [Reddi-Pet on Devpost](https://devpost.com/software/reddi-pet)
+
+![Reddi-Pet concept illustration showing the product experience.](./assets/concept.png)


### PR DESCRIPTION
## Summary
- embed the new concept illustration into the documentation index page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd4ad0552883298a329c6e569b001e