### PR TITLE
Add micro-interactions and feedback to pet UI

### DIFF
--- a/src/client/ascii.ts
+++ b/src/client/ascii.ts
@@ -1,14 +1,14 @@
 export type Mood = 'idle' | 'happy' | 'hungry' | 'dirty' | 'sleep' | 'bored';
 
-export function petSprite(mood: Mood, frame = 0): string {
-  // Two simple frames for a subtle “blink/wiggle”
-  const blink = frame % 2 === 0 ? "o" : "-";
+export function petSprite(mood: Mood, blinkOn = false): string {
+  const eye = blinkOn ? '-' : '•';
+  const eyes = `${eye}${eye}`;
   if (mood === 'happy') {
     return String.raw`
   .-""""-.
  /  .--.  \
 |  /    \  |
-| |  ${blink}${blink}  | |
+| |  ${eyes}  | |
 |  \ -- /  |
  \  '--'  /
   '-.__.-'`;
@@ -18,7 +18,7 @@ export function petSprite(mood: Mood, frame = 0): string {
   .-""""-.
  /  .--.  \
 |  /    \  |
-| |  ${blink}_  | |
+| |  ${eye}_  | |
 |  \ __/   |
  \  '--.  /
   '-.__\-'`;
@@ -28,7 +28,7 @@ export function petSprite(mood: Mood, frame = 0): string {
   .-""""-.
  /  .--.  \
 |  /    \  |
-| |  ${blink}${blink}  | |  ~
+| |  ${eyes}  | |  ~
 |  \ .. /  | ~
  \  '--'  /  ~
   '-.__.-'`;
@@ -58,7 +58,7 @@ export function petSprite(mood: Mood, frame = 0): string {
   .-""""-.
  /  .--.  \
 |  /    \  |
-| |  ${blink}${blink}  | |
+| |  ${eyes}  | |
 |  \ __/  |
  \  '--'  /
   '-.__.-'`;

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -42,6 +42,7 @@ html,body,#root{ height:100%; margin:0; background: radial-gradient(1200px 800px
   position: relative;
   overflow: hidden;
 }
+.screen.flash{ box-shadow: inset 0 0 60px rgba(127,255,212,.14), inset 0 0 2px rgba(255,255,255,0.08); transition: box-shadow .2s ease; }
 
 .screen::before{
   content:"";
@@ -67,6 +68,8 @@ html,body,#root{ height:100%; margin:0; background: radial-gradient(1200px 800px
   background: linear-gradient(90deg, var(--accent) 0%, var(--accent-2) 100%);
   transition: width .35s ease, background .2s ease;
 }
+.bar > span.pulse{ animation: barPulse .4s ease; }
+@keyframes barPulse{ 0%{filter:brightness(1)} 40%{filter:brightness(1.35)} 100%{filter:brightness(1)} }
 .bar[data-state="warn"] > span{ background: linear-gradient(90deg, var(--bar-fill-warn), #ffe08a); }
 .bar[data-state="bad"]  > span{ background: linear-gradient(90deg, var(--bar-fill-bad), #ff9a9a); }
 
@@ -90,7 +93,7 @@ html,body,#root{ height:100%; margin:0; background: radial-gradient(1200px 800px
   transition: transform .06s ease, box-shadow .2s ease, background .2s ease;
   letter-spacing:1px;
 }
-.btn:hover{ box-shadow: 0 4px 0 rgba(0,0,0,.45), 0 14px 24px rgba(0,0,0,.3); }
+.btn:hover{ box-shadow: 0 2px 0 rgba(0,0,0,.5), 0 14px 28px rgba(0,0,0,.35); }
 .btn:active{ transform: translateY(1px); }
 .btn--primary{ background: linear-gradient(180deg, #1d7458, #125a45); }
 .btn--danger{ background: linear-gradient(180deg, #9a2e26, #7e211a); }


### PR DESCRIPTION
## Summary
- add micro-interaction helpers including audio click stub, screen flash, and idle blink logic
- convert stats to a pulsing component and update footer copy with stage info
- refresh ASCII eye rendering for the blink and tweak button hover styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd4a0ab8308329950e21871b86be14