### PR TITLE
Add Adam's Hub link to docs footer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -140,6 +140,7 @@
       <span class="text-slate-400">© <span id="year"></span> Reddi-Pet</span>
       <div class="flex items-center gap-4">
         <a href="https://github.com/uxillary/reddi" class="nav">GitHub</a>
+        <a href="https://adamj.link" class="nav">Adam's Hub</a>
         <a href="https://redditfunandgames.devpost.com/" class="nav">Hackathon</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a footer link on the docs homepage pointing to Adam's Hub at https://adamj.link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd6ff37d7083298123358fdab19729